### PR TITLE
Extracts the contact user identity into separate object

### DIFF
--- a/Gerulus.Core/Contacts/ContactUser.cs
+++ b/Gerulus.Core/Contacts/ContactUser.cs
@@ -3,23 +3,21 @@ using Gerulus.Core.Contacts.Events;
 
 namespace Gerulus.Core.Contacts;
 
-public class ContactUser : AggregateRoot<CompositeId<UserId, UserId>>
+public class ContactUser : AggregateRoot<ContactUserId>
 {
     private HashSet<Contact> ContactsList { get; } = new();
     public ImmutableList<Contact> Contacts => ContactsList.ToImmutableList();
 
-    public UserId CoreUser { get; }
-    public UserId Identity { get; }
+    public UserId CoreUser => Id.Core;
+    public UserId Identity => Id.Identity;
 
     public ContactUser(UserId user) : this(user, user)
     {
     }
 
     public ContactUser(UserId actualUser, UserId identityUser) 
-        : base(CompositeId.From(actualUser, identityUser))
+        : base(new ContactUserId(actualUser, identityUser))
     {
-        CoreUser = actualUser;
-        Identity = identityUser;
     }
 
     public ContactUser? GetContactWith(ContactUser user)

--- a/Gerulus.Core/Contacts/ContactUserId.cs
+++ b/Gerulus.Core/Contacts/ContactUserId.cs
@@ -1,0 +1,3 @@
+namespace Gerulus.Core.Contacts;
+
+public readonly record struct ContactUserId(UserId Core, UserId Identity) : IEquatable<ContactUserId>;


### PR DESCRIPTION
This will allow other aggregates to more easily reference a contact user aggregate.